### PR TITLE
Make mod serialize public

### DIFF
--- a/zcash_primitives/src/lib.rs
+++ b/zcash_primitives/src/lib.rs
@@ -41,7 +41,7 @@ pub mod primitives;
 pub mod prover;
 pub mod redjubjub;
 pub mod sapling;
-mod serialize;
+pub mod serialize;
 pub mod transaction;
 mod util;
 pub mod zip32;


### PR DESCRIPTION
Make the serialize mod public so light clients can use the same serialization