### PR TITLE
transparent inputs should use serialize_der()

### DIFF
--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -456,7 +456,6 @@ impl<R: RngCore + CryptoRng> Builder<R> {
         //
 
         let mut ctx = prover.new_sapling_proving_context();
-        let anchor = self.anchor.expect("anchor was set if spends were added");
 
         // Pad Sapling outputs
         let orig_outputs_len = outputs.len();
@@ -473,40 +472,44 @@ impl<R: RngCore + CryptoRng> Builder<R> {
         tx_metadata.output_indices.resize(orig_outputs_len, 0);
 
         // Create Sapling SpendDescriptions
-        for (i, (pos, spend)) in spends.iter().enumerate() {
-            let proof_generation_key = spend.extsk.expsk.proof_generation_key(&JUBJUB);
+        if spends.len() > 0 {
+            let anchor = self.anchor.expect("anchor was set if spends were added");
+        
+            for (i, (pos, spend)) in spends.iter().enumerate() {
+                let proof_generation_key = spend.extsk.expsk.proof_generation_key(&JUBJUB);
 
-            let mut nullifier = [0u8; 32];
-            nullifier.copy_from_slice(&spend.note.nf(
-                &proof_generation_key.into_viewing_key(&JUBJUB),
-                spend.witness.position,
-                &JUBJUB,
-            ));
+                let mut nullifier = [0u8; 32];
+                nullifier.copy_from_slice(&spend.note.nf(
+                    &proof_generation_key.into_viewing_key(&JUBJUB),
+                    spend.witness.position,
+                    &JUBJUB,
+                ));
 
-            let (zkproof, cv, rk) = prover
-                .spend_proof(
-                    &mut ctx,
-                    proof_generation_key,
-                    spend.diversifier,
-                    spend.note.r,
-                    spend.alpha,
-                    spend.note.value,
-                    anchor,
-                    spend.witness.clone(),
-                )
-                .map_err(|()| Error::SpendProof)?;
+                let (zkproof, cv, rk) = prover
+                    .spend_proof(
+                        &mut ctx,
+                        proof_generation_key,
+                        spend.diversifier,
+                        spend.note.r,
+                        spend.alpha,
+                        spend.note.value,
+                        anchor,
+                        spend.witness.clone(),
+                    )
+                    .map_err(|()| Error::SpendProof)?;
 
-            self.mtx.shielded_spends.push(SpendDescription {
-                cv,
-                anchor: anchor,
-                nullifier,
-                rk,
-                zkproof,
-                spend_auth_sig: None,
-            });
+                self.mtx.shielded_spends.push(SpendDescription {
+                    cv,
+                    anchor: anchor,
+                    nullifier,
+                    rk,
+                    zkproof,
+                    spend_auth_sig: None,
+                });
 
-            // Record the post-randomized spend location
-            tx_metadata.spend_indices[*pos] = i;
+                // Record the post-randomized spend location
+                tx_metadata.spend_indices[*pos] = i;
+            }
         }
 
         // Create Sapling OutputDescriptions
@@ -621,9 +624,13 @@ impl<R: RngCore + CryptoRng> Builder<R> {
                 let msg = secp256k1::Message::from_slice(&sighash).expect("32 bytes");
                 let sig = self.legacy.secp.sign(&msg, &info.sk);
 
+                // Signature has to have "SIGHASH_ALL" appended to it
+                let mut sig_bytes: Vec<u8> = sig.serialize_der()[..].to_vec();
+                sig_bytes.extend(&[SIGHASH_ALL as u8]);
+
                 // P2PKH scriptSig
                 self.mtx.vin[i].script_sig =
-                    Script::default() << &sig.serialize_compact()[..] << &info.pubkey[..];
+                    Script::default() << &sig_bytes[..] << &info.pubkey[..];
             }
         }
 


### PR DESCRIPTION
- Create the anchor only if there are shielded inputs to prevent crash
- signature hash format that zcashd expects is `serialize_der() + (byte) SIGHASH_ALL`

Note: github is showing a larger diff than is needed because of whitespace. Please add &w=1 to the github URL to see the proper diff